### PR TITLE
Fixed empty submissions - swapped attribute 'disabled' to 'readonly'

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 				<h2>get in touch</h2>
 				  <label>
 				    <span><i class="fa-solid fa-user"></i></span>
-				    <input name="name" placeholder="name" required>
+				    <input type="name" name="name" placeholder="name" required>
 				  </label>
 				  <label>
 				    <span><i class="fa-solid fa-at"></i></span>
@@ -86,6 +86,7 @@
 				  <!-- Settings -->
 				  <!-- <input type="hidden" name="_next" value="http://localhost:8080/thanks.html"> -->
 				  <input type="hidden" name="_template" value="table">
+				  <input type="hidden" name="_autoresponse" value="Thank you! Here is a copy of your message.">
 
 				  <button type="submit">send ↗</button>
 			</form>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -28,7 +28,7 @@ function thankyou() {
     // Disable Form
     inputs = contactForm.querySelectorAll('input, select, textarea, button');
     for (i of inputs) {
-        i.disabled = true;
+        i.readOnly = true;
     }
     // Hide Button - you can do this instead!
     buttons = contactForm.querySelectorAll('button');


### PR DESCRIPTION
So it turns out form input fields are NOT submitted when they are set to 'disabled', even when they are toggled on the submit event. This caused email submissions to be blank.

Intended solution is to toggle input fields to 'readonly' after submission, rather than 'disabled', to prevent them from being manipulated/submitted again.